### PR TITLE
Enable babel in ethereum, berachain catalog

### DIFF
--- a/crates/runtime-docker-compose/src/runtime.rs
+++ b/crates/runtime-docker-compose/src/runtime.rs
@@ -148,8 +148,30 @@ impl DockerRuntime {
         let mut services = HashMap::new();
         let compose_dir = std::path::Path::new(&self.dir_path).join(&manifest.name);
 
+        // First pass: collect all ports from all pods/specs
+        let mut port_registry: HashMap<String, HashMap<String, u16>> = HashMap::new();
+        for (_, pod) in &manifest.pods {
+            for (spec_name, spec) in &pod.specs {
+                let service_name = spec_name.clone();
+                let mut service_ports = HashMap::new();
+
+                for arg in &spec.args {
+                    if let spec::Arg::Port { name, preferred } = arg {
+                        service_ports.insert(name.clone(), *preferred);
+                    }
+                }
+
+                port_registry.insert(service_name, service_ports);
+            }
+        }
+
         for (pod_name, pod) in manifest.pods {
             for (spec_name, spec) in pod.specs {
+                if spec.image == "babel" {
+                    // TODO: Babel skipped for now until the image is published
+                    continue;
+                }
+
                 let image = format!(
                     "{}:{}",
                     spec.image,
@@ -180,21 +202,31 @@ impl DockerRuntime {
 
                 for arg in spec.args {
                     let cleaned_arg = match arg {
-                        spec::Arg::Value(value) => Some(value),
-                        spec::Arg::Dir { path, .. } => Some(path),
+                        spec::Arg::Value(value) => Ok(Some(value)),
+                        spec::Arg::Dir { path, .. } => Ok(Some(path)),
                         spec::Arg::Port { preferred, .. } => {
                             ports.push(Port {
                                 host: preferred,
                                 container: preferred,
                             });
-                            Some(format!("{}", preferred))
+                            Ok(Some(format!("{}", preferred)))
                         }
                         spec::Arg::File(file) => {
                             artifacts_to_process.push(spec::Artifacts::File(file));
-                            None
+                            Ok(None)
                         }
-                        spec::Arg::Ref { .. } => format!("").into(),
-                    };
+                        spec::Arg::Ref { name, port } => {
+                            if let Some(service_ports) = port_registry.get(&name) {
+                                if let Some(port_num) = service_ports.get(&port) {
+                                    Ok(Some(format!("http://{}:{}", name, port_num)))
+                                } else {
+                                    Err(eyre::eyre!("Ref port {} does not exists", port))
+                                }
+                            } else {
+                                Err(eyre::eyre!("Ref name {} does not exists", name))
+                            }
+                        }
+                    }?;
                     if let Some(cleaned_arg) = cleaned_arg {
                         command.push(cleaned_arg);
                     }

--- a/crates/spec/src/lib.rs
+++ b/crates/spec/src/lib.rs
@@ -286,3 +286,28 @@ impl Into<Spec> for SpecBuilder {
         self.build()
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct Babel {
+    pub node_type: String,
+    pub rpc_url: Arg,
+}
+
+impl Babel {
+    pub fn new(node_type: impl Into<String>, rpc_url: impl Into<Arg>) -> Self {
+        Self {
+            node_type: node_type.into(),
+            rpc_url: rpc_url.into(),
+        }
+    }
+
+    pub fn spec(self) -> Spec {
+        Spec::builder()
+            .image("babel")
+            .tag("latest")
+            .arg2("--node-type", self.node_type)
+            .arg2("--rpc-url", self.rpc_url)
+            .arg2("--addr", "0.0.0.0:3000")
+            .build()
+    }
+}


### PR DESCRIPTION
This PR enables babel in the `ethereum` and `berachain` catalogs. It still does not run since the images have not been published yet.