### PR TITLE
Add structs to define docker compose volume + serialize test

### DIFF
--- a/crates/runtime-docker-compose/fixtures/docker-compose-with-volumes.yaml
+++ b/crates/runtime-docker-compose/fixtures/docker-compose-with-volumes.yaml
@@ -1,0 +1,15 @@
+services:
+  test-service:
+    image: test-image:latest
+    command: []
+    volumes:
+    - /host/path:/container/path
+networks:
+  test: null
+volumes:
+  mydata:
+    driver: local
+    driver_opts:
+      type: nfs
+    labels:
+      description: My data volume


### PR DESCRIPTION
This PR models the volumes and service volumes as structs in the docker compose Rust spec and adds a unit test that verifies the serialization to yaml works as expected.